### PR TITLE
latest-geo: session-IP compare + ipinfo bootstrap

### DIFF
--- a/assets/javascripts/discourse/initializers/rr-geo-ipinfo.js
+++ b/assets/javascripts/discourse/initializers/rr-geo-ipinfo.js
@@ -1,6 +1,29 @@
 import { ajax } from "discourse/lib/ajax";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
+const GEO_TOKENS_KEY = "geo.tokens";
+const GEO_LAST_IP_KEY = "geo.lastIp";
+const GEO_CHECKED_AT_KEY = "geo.checkedAt";
+const GEO_LAST_RELOAD_AT_KEY = "geo.lastReloadAt";
+
+const GEO_TTL_MS = 6 * 60 * 60 * 1000; // 6h
+const GEO_POLL_INTERVAL_MS = 0; // set >0 to enable periodic checks
+const GEO_RELOAD_MIN_INTERVAL_MS = 60 * 1000; // 60s
+
+const IPINFO_URL = "https://ipinfo.io/json";
+
+function nowMs() {
+  return Date.now ? Date.now() : new Date().getTime();
+}
+
+function shouldCheckAgain() {
+  const last = parseInt(localStorage.getItem(GEO_CHECKED_AT_KEY) || "0", 10);
+  if (!last) {
+    return true;
+  }
+  return nowMs() - last >= GEO_TTL_MS;
+}
+
 function tokenizePieces(...parts) {
   const out = new Set();
   for (const p of parts) {
@@ -15,14 +38,161 @@ function tokenizePieces(...parts) {
   return Array.from(out);
 }
 
+function tokensChanged(newCsv) {
+  const prev = (localStorage.getItem(GEO_TOKENS_KEY) || "").trim();
+  return prev !== (newCsv || "").trim();
+}
+
+function dispatchGeoUpdated() {
+  try {
+    window.dispatchEvent(new CustomEvent("rr-geo-updated"));
+  } catch {
+    /* no-op */
+  }
+}
+
+function hardReloadIfAllowed({ enabled = true } = {}) {
+  if (!enabled) {
+    return;
+  }
+  if (document.visibilityState !== "visible") {
+    return;
+  }
+  const last = parseInt(
+    localStorage.getItem(GEO_LAST_RELOAD_AT_KEY) || "0",
+    10
+  );
+  if (nowMs() - last < GEO_RELOAD_MIN_INTERVAL_MS) {
+    return;
+  }
+  localStorage.setItem(GEO_LAST_RELOAD_AT_KEY, String(nowMs()));
+  window.location.reload();
+}
+
+async function fetchSessionIp() {
+  try {
+    const r = await fetch("/session/current.json", {
+      headers: { Accept: "application/json" },
+    });
+    if (r.ok) {
+      const j = await r.json();
+      return j.client_ip || null;
+    }
+  } catch {}
+  try {
+    const r2 = await fetch("/site.json", {
+      headers: { Accept: "application/json" },
+    });
+    if (r2.ok) {
+      const s = await r2.json();
+      return s.client_ip || null;
+    }
+  } catch {}
+  return null;
+}
+
 async function fetchIpinfo() {
-  const res = await fetch("https://ipinfo.io/json", {
+  const res = await fetch(IPINFO_URL, {
     headers: { Accept: "application/json" },
   });
   if (!res.ok) {
     throw new Error(`ipinfo ${res.status}`);
   }
-  return res.json(); // { city, region, country, ... }
+  // { ip, city, region, country, ... }
+  return res.json();
+}
+
+async function updateProfileLocation(
+  api,
+  { city, region, onlyIfBlank = true }
+) {
+  const currentUser = api.getCurrentUser?.();
+  if (!currentUser) {
+    return;
+  }
+  if (onlyIfBlank && currentUser.location) {
+    return;
+  }
+
+  const loc = city && region ? `${city}, ${region}` : city || region || "";
+  if (!loc) {
+    return;
+  }
+
+  try {
+    await ajax(`/u/${encodeURIComponent(currentUser.username)}.json`, {
+      type: "PUT",
+      data: { location: loc },
+    });
+    currentUser.location = loc;
+  } catch {}
+}
+
+function hasProfileLocation(api) {
+  const currentUser = api.getCurrentUser?.();
+  return !!currentUser?.location;
+}
+
+function setDefaultTokensIfMissing() {
+  if ((localStorage.getItem(GEO_TOKENS_KEY) || "").trim()) {
+    return;
+  }
+  localStorage.setItem(GEO_TOKENS_KEY, "toronto,gta,ontario,canada");
+}
+
+async function bootstrapFromIpinfo(api, { persistIp }) {
+  const j = await fetchIpinfo();
+  const city = j?.city;
+  const region = j?.region;
+  const country = j?.country;
+
+  const toks = tokenizePieces(city, region, country).filter(Boolean);
+  const csv = toks.length ? toks.join(",") : "toronto,gta,ontario,canada";
+
+  if (tokensChanged(csv)) {
+    localStorage.setItem(GEO_TOKENS_KEY, csv);
+    dispatchGeoUpdated();
+  }
+  await updateProfileLocation(api, { city, region, onlyIfBlank: true });
+
+  if (persistIp) {
+    localStorage.setItem(GEO_LAST_IP_KEY, persistIp || j?.ip || "");
+  }
+}
+
+async function refreshGeoIfNeeded(api, { force = false } = {}) {
+  if (!force && !shouldCheckAgain()) {
+    return;
+  }
+
+  setDefaultTokensIfMissing();
+
+  const sessionIp = await fetchSessionIp();
+  const lastIp = localStorage.getItem(GEO_LAST_IP_KEY) || "";
+  const firstRun = !lastIp;
+  const ipChanged = sessionIp && lastIp && sessionIp !== lastIp;
+
+  const needsBootstrap = !hasProfileLocation(api);
+  if (needsBootstrap || ipChanged || firstRun || force) {
+    try {
+      await bootstrapFromIpinfo(api, { persistIp: sessionIp });
+      if (ipChanged && !firstRun) {
+        hardReloadIfAllowed({
+          enabled: true,
+        });
+      }
+    } catch {
+      if (!(localStorage.getItem(GEO_TOKENS_KEY) || "").trim()) {
+        localStorage.setItem(GEO_TOKENS_KEY, "toronto,gta,ontario,canada");
+        dispatchGeoUpdated();
+      }
+    }
+  } else if (sessionIp && firstRun) {
+    // runs on init?
+    localStorage.setItem(GEO_LAST_IP_KEY, sessionIp);
+  }
+
+  localStorage.setItem(GEO_CHECKED_AT_KEY, String(nowMs()));
 }
 
 export default {
@@ -30,58 +200,20 @@ export default {
   initialize() {
     withPluginApi(async (api) => {
       const ss = api.container.lookup("service:site-settings");
-      if (!ss.rr_geo_enabled) {
+      if (!ss?.rr_geo_enabled) {
         return;
       }
+      await refreshGeoIfNeeded(api, { force: true });
 
-      const currentUser = api.getCurrentUser?.();
-      if (!currentUser) {
-        return;
-      }
-      if (sessionStorage.getItem("geo.ipinfo.done") === "1") {
-        return;
-      }
-      sessionStorage.setItem("geo.ipinfo.done", "1");
-      if ((localStorage.getItem("geo.tokens") || "").trim()) {
-        return;
-      }
-
-      let city, region, country;
-      try {
-        const j = await fetchIpinfo();
-        city = j?.city;
-        region = j?.region;
-        country = j?.country; // ISO, e.g., "CA"
-      } catch (_e) {
-        localStorage.setItem("geo.tokens", "toronto,gta,ontario,canada");
-        return;
-      }
-
-      // Build geo tokens for the sorter
-      const tokens = tokenizePieces(city, region, country).filter(Boolean);
-      if (tokens.length) {
-        localStorage.setItem("geo.tokens", tokens.join(","));
-      } else {
-        localStorage.setItem("geo.tokens", "toronto,gta,ontario,canada");
-      }
-      if (
-        ss.rr_set_profile_location_if_blank &&
-        !currentUser.location &&
-        (city || region)
-      ) {
-        try {
-          await ajax(`/u/${encodeURIComponent(currentUser.username)}.json`, {
-            type: "PUT",
-            data: {
-              location:
-                city && region ? `${city}, ${region}` : city || region || "",
-            },
-          });
-          currentUser.location =
-            city && region ? `${city}, ${region}` : city || region || "";
-        } catch {
-          // ignore
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "visible") {
+          refreshGeoIfNeeded(api);
         }
+      });
+      window.addEventListener("online", () => refreshGeoIfNeeded(api));
+
+      if (GEO_POLL_INTERVAL_MS > 0) {
+        setInterval(() => refreshGeoIfNeeded(api), GEO_POLL_INTERVAL_MS);
       }
     });
   },

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-latest-geo
-# about: GEO prioritization if the user has not set it already
-# version: 0.2.1
+# about: GEO prioritization if the user has not set it already + session IP exposure
+# version: 0.2.5
 # authors: Renovation.Reviews
 
 enabled_site_setting :rr_geo_enabled
@@ -21,41 +21,71 @@ after_initialize do
         patterns.map { |p| ActiveRecord::Base.connection.quote(p) }.join(",")
       end
     end
-  end
 
-  ::TopicQuery.class_eval do
-    def list_latest(*args)
-      options = args.first || {}
-      rel = latest_results(options)
+    module TopicQueryExtension
+      def latest_results(options = {})
+        rel = super
+        return rel unless SiteSetting.rr_geo_enabled
 
-      if SiteSetting.rr_geo_enabled && @guardian&.user
-        location = @guardian.user.user_profile&.location
+        user = @guardian&.user
+        return rel unless user
+
+        location = user.user_profile&.location
         tokens = ::RrGeo::Util.tokens_from_location(location)
+        return rel if tokens.blank?
 
-        if tokens.present?
-          patterns = tokens.map { |t| "%#{ActiveRecord::Base.sanitize_sql_like(t)}%" }
-          q_array = ::RrGeo::Util.quote_patterns(patterns)
-          rel =
-            rel
-              .joins(<<~SQL)
-              LEFT JOIN topic_tags tt ON tt.topic_id = topics.id
-              LEFT JOIN tags tg ON tg.id = tt.tag_id
-              LEFT JOIN categories c ON c.id = topics.category_id
-            SQL
-              .select(<<~SQL)
-              topics.*,
-              CASE
-                WHEN topics.title ILIKE ANY (ARRAY[#{q_array}])
-                 OR tg.name       ILIKE ANY (ARRAY[#{q_array}])
-                 OR c.name        ILIKE ANY (ARRAY[#{q_array}])
-                THEN 0 ELSE 1
-              END AS rr_geo_rank
-            SQL
-              .distinct(true)
-              .reorder(Arel.sql("rr_geo_rank ASC, topics.created_at DESC"))
-        end
+        patterns = tokens.map { |t| "%#{ActiveRecord::Base.sanitize_sql_like(t)}%" }
+        q_array = ::RrGeo::Util.quote_patterns(patterns)
+
+        rel
+          .joins(<<~SQL)
+            LEFT JOIN topic_tags tt ON tt.topic_id = topics.id
+            LEFT JOIN tags tg ON tg.id = tt.tag_id
+            LEFT JOIN categories c ON c.id = topics.category_id
+          SQL
+          .select(<<~SQL)
+            topics.*,
+            CASE
+              WHEN topics.title ILIKE ANY (ARRAY[#{q_array}])
+                OR tg.name      ILIKE ANY (ARRAY[#{q_array}])
+                OR c.name       ILIKE ANY (ARRAY[#{q_array}])
+              THEN 0 ELSE 1
+            END AS rr_geo_rank
+          SQL
+          .distinct(true)
+          .reorder(Arel.sql("rr_geo_rank ASC, topics.created_at DESC"))
       end
-      create_list(:latest, {}, rel)
     end
   end
+
+  ::TopicQuery.prepend(::RrGeo::TopicQueryExtension)
+
+  require_dependency "application_controller"
+  require "request_store"
+
+  module ::RrGeo::IpTracking
+    def self.prepended(base)
+      base.before_action :rr_track_client_ip
+    end
+
+    private
+
+    def rr_track_client_ip
+      curr_ip = request.remote_ip
+      last_ip = session[:rr_last_ip]
+
+      RequestStore.store[:rr_client_ip] = curr_ip
+      RequestStore.store[:rr_ip_changed] = last_ip.present? && last_ip != curr_ip
+
+      session[:rr_last_ip] = curr_ip
+    end
+  end
+
+  ::ApplicationController.prepend(::RrGeo::IpTracking)
+
+  add_to_serializer(:current_user, :client_ip) { RequestStore.store[:rr_client_ip] }
+  add_to_serializer(:current_user, :ip_changed) { !!RequestStore.store[:rr_ip_changed] }
+
+  add_to_serializer(:site, :client_ip) { RequestStore.store[:rr_client_ip] }
+  add_to_serializer(:site, :ip_changed) { !!RequestStore.store[:rr_ip_changed] }
 end


### PR DESCRIPTION
If no profile location: fetch via ipinfo and seed tokens. On IP change (backend /session/current.json vs stored): refresh via ipinfo, update tokens/location, dispatch rr-geo-updated, optional hard reload (visible, rate-limited). Expose client_ip/ip_changed via CurrentUser & Site serializers (require request_store). Keep GEO ranking via TopicQuery prepend; TTL + focus/online rechecks.